### PR TITLE
Fix namespace URI

### DIFF
--- a/ontoscript.coffee
+++ b/ontoscript.coffee
@@ -2638,7 +2638,7 @@ rdfs.addDatatypeProperty("label")
 prov.addDatatypeProperty("generatedAtTime")
 
 
-METAMODEL "http://mercator.iac.es/onto/metamodels/ontoscript" : "ontoscript"
+METAMODEL "http://www.mercator.iac.es/onto/metamodels/ontoscript" : "ontoscript"
 ontoscript.addDatatypeProperty("counter")
 ontoscript.addDatatypeProperty("hasViewCategory")
 ontoscript.addDatatypeProperty("hasViewType")


### PR DESCRIPTION
Due to this error, triples such as ?x :counter ?y were being inserted
with the wrong namespace. Hence, when they were queried by a system like
OntoManager, these triples could not be retrieved (as OntoManager was
querying them with the correct namespace).

This problem was discovered when the ordering of query results went bad
in OntoManager, due to the "wrong" ?x :counter ?y triples that were
inserted in the jsonld output files of Ontoscript.